### PR TITLE
Intercept range upperBound < lowerBound in EventPeriod

### DIFF
--- a/HTWDD/Main Categories/General/Models/EventPeriod.swift
+++ b/HTWDD/Main Categories/General/Models/EventPeriod.swift
@@ -26,6 +26,10 @@ struct EventPeriod: Codable, Hashable {
     }
 
     func contains(date: EventDate) -> Bool {
+        if end.date < begin.date {
+            Log.error("In line \(#line) in \(#file): upperBound of a range should not be smaller than the lowerBound! Investigate if data in backend is inconsistent!")
+            return false
+        }
         return (begin.date...end.date).contains(date.date)
     }
 


### PR DESCRIPTION
Would have previously caused the app to throw an exception if the data coming from the backend was inconsistent. i.e. an event period’s start date would come after the end date.